### PR TITLE
add reference and link to the Dir class in Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ attribute that gets set on initialization.
 
 You should write code that responds to
 `MP3Importer.new('./spec/fixtures').import`. Google around for how to get a list
-of files in a directory! Make sure you only get `.mp3` files.
+of files in a directory! Hint: you may want to look at the [documentation for Ruby's built-in Dir class](https://ruby-doc.org/core-2.6.1/Dir.html). Make sure you only get `.mp3` files.
 
 Since we have to send the filenames to the `Song` class, we'll end up calling
 the following code in the `#import` method:


### PR DESCRIPTION
Due to a fair amount of student confusion, I think it'd be a good idea to put a reference to the Dir class in the readme since it's a bit of an advanced topic at this point in the curriculum. I linked the documentation (https://ruby-doc.org/core-2.6.1/Dir.html) as well to hopefully get them on the right track, but it may even be warranted to specify looking at either the glob, entries, or each_child methods since any of those could be used to get to the solution.